### PR TITLE
Replace `pdftexcmds` and `shellesc` packages with expl3 functions

### DIFF
--- a/doc/latex/tcolorbox/CHANGES.md
+++ b/doc/latex/tcolorbox/CHANGES.md
@@ -39,6 +39,10 @@ and this project adheres to
 - Distinct `savelowerto`/`redirectlowerto` file names inside the documentation (issue #248)
 - Updated documentation and warnings for the interaction between `saveto`
     and `savelowerto` (issue #249)
+- Library `external`: package loading of `pdftexcmds` and `shellesc` removed.
+    expl3 functions are used as drop-in replacements.
+- Libraries `listings`, `listingsutf8`, and `minted`: package loading of `pdftexcmds`
+    and `shellesc` removed.
 
 ### Deprecated
 

--- a/tex/latex/tcolorbox/tcbexternal.code.tex
+++ b/tex/latex/tcolorbox/tcbexternal.code.tex
@@ -64,8 +64,8 @@
     \group_begin:
     \char_set_catcode_other:n { `\" }
     \iow_term:e { ===~Compile~external~'\tcbexternal@job@name':~ }
-    \iow_open:Nn \g__tcb_out_iow { \tcbexternal@run@tex }
-    \iow_now:Ne \g__tcb_out_iow
+    \iow_open:Nn \g__tcobox_out_iow { \tcbexternal@run@tex }
+    \iow_now:Ne \g__tcobox_out_iow
       {
         \token_to_str:N \gdef \token_to_str:N \TCBEXTERNALINPUT
           { "\tcbexternal@job@source" } \iow_newline:
@@ -75,10 +75,10 @@
           { \exp_not:o {\tcbexternal@preamble} }
       }
     \tl_if_empty:NF \tcbexternal@preclass
-      { \iow_now:No \g__tcb_out_iow { \tcbexternal@preclass } }
-    \iow_now:Ne \g__tcb_out_iow
+      { \iow_now:No \g__tcobox_out_iow { \tcbexternal@preclass } }
+    \iow_now:Ne \g__tcobox_out_iow
         { \token_to_str:N \input {"\jobname.tex"} }
-    \iow_close:N \g__tcb_out_iow
+    \iow_close:N \g__tcobox_out_iow
     \int_step_inline:nn { \tcbexternal@runs }
       {
         \sys_shell_now:e

--- a/tex/latex/tcolorbox/tcbexternal.code.tex
+++ b/tex/latex/tcolorbox/tcbexternal.code.tex
@@ -65,7 +65,7 @@
     \char_set_catcode_other:n { `\" }
     \iow_term:e { ===~Compile~external~'\tcbexternal@job@name':~ }
     \tcb@allocate@tcb@out
-    \iow_open:No \tcb@out { \tcbexternal@run@tex }
+    \iow_open:Nn \tcb@out { \tcbexternal@run@tex }
     \iow_now:Ne \tcb@out
       {
         \token_to_str:N \gdef \token_to_str:N \TCBEXTERNALINPUT
@@ -78,13 +78,13 @@
     \tl_if_empty:NF \tcbexternal@preclass
       { \iow_now:No \tcb@out { \tcbexternal@preclass } }
     \iow_now:No \tcb@out
-        { \token_to_str:N \input{"\jobname.tex"} }
+        { \token_to_str:N \input {"\jobname.tex"} }
     \iow_close:N \tcb@out
     \int_step_inline:nn { \tcbexternal@runs }
       {
         \sys_shell_now:e
           {
-            \tcbexternal@compiler~
+            \tcbexternal@compiler \c_space_tl
             -shell-escape~
             -halt-on-error~
             -interaction=batchmode~

--- a/tex/latex/tcolorbox/tcbexternal.code.tex
+++ b/tex/latex/tcolorbox/tcbexternal.code.tex
@@ -64,9 +64,8 @@
     \group_begin:
     \char_set_catcode_other:n { `\" }
     \iow_term:e { ===~Compile~external~'\tcbexternal@job@name':~ }
-    \tcb@allocate@tcb@out
-    \iow_open:Nn \g_tcb_out_iow { \tcbexternal@run@tex }
-    \iow_now:Ne \g_tcb_out_iow
+    \iow_open:Nn \g__tcb_out_iow { \tcbexternal@run@tex }
+    \iow_now:Ne \g__tcb_out_iow
       {
         \token_to_str:N \gdef \token_to_str:N \TCBEXTERNALINPUT
           { "\tcbexternal@job@source" } \iow_newline:
@@ -76,10 +75,10 @@
           { \exp_not:o {\tcbexternal@preamble} }
       }
     \tl_if_empty:NF \tcbexternal@preclass
-      { \iow_now:No \g_tcb_out_iow { \tcbexternal@preclass } }
-    \iow_now:Ne \g_tcb_out_iow
+      { \iow_now:No \g__tcb_out_iow { \tcbexternal@preclass } }
+    \iow_now:Ne \g__tcb_out_iow
         { \token_to_str:N \input {"\jobname.tex"} }
-    \iow_close:N \g_tcb_out_iow
+    \iow_close:N \g__tcb_out_iow
     \int_step_inline:nn { \tcbexternal@runs }
       {
         \sys_shell_now:e

--- a/tex/latex/tcolorbox/tcbexternal.code.tex
+++ b/tex/latex/tcolorbox/tcbexternal.code.tex
@@ -21,13 +21,6 @@
 
 \tcbuselibrary{pro@cessing}
 
-{
-\catcode`\"=12
-\xdef\tcbexternal@normal@dq{"}
-\catcode`\"=13
-\gdef\tcbexternal@activate@normal@dq{\let"=\tcbexternal@normal@dq}
-}
-
 \long\def\tcbifexternal#1#2{%
   \ifdefined\TCBEXTERNALINPUT%
     #1%
@@ -65,31 +58,45 @@
   \edef\tcbexternal@job@pdf{\expandonce{\tcbexternal@job@name.pdf}}%
 }
 
-\def\tcbexternal@corecompile{%
-  \begingroup%
-  \ifnum\the\catcode`\"=13 \tcbexternal@activate@normal@dq\fi%
-  \message{=== Compile external '\tcbexternal@job@name': }%
-  \tcb@allocate@tcb@out%
-  \immediate\openout\tcb@out="\tcbexternal@run@tex"
-  \immediate\write\tcb@out{\string\gdef\string\TCBEXTERNALINPUT{"\tcbexternal@job@source"}}%
-  \immediate\write\tcb@out{\string\gdef\string\TCBEXTERNALSAFETY{\tcbexternal@safety}}%
-  \immediate\write\tcb@out{\string\gdef\string\TCBEXTERNALPREAMBLE{\expandonce{\tcbexternal@preamble}}}%
-  \ifdefempty{\tcbexternal@preclass}{}{\immediate\write\tcb@out{\expandonce{\tcbexternal@preclass}}}%
-  \immediate\write\tcb@out{\string\input{"\jobname.tex"}}%
-  \immediate\closeout\tcb@out%
-  \foreach \n in {1,...,\tcbexternal@runs}
-  {%
-    \UseName{sys_shell:now:e}{%
-      \tcbexternal@compiler\space
-      -shell-escape
-      -halt-on-error
-      -interaction=batchmode
-      -jobname="\tcbexternal@job@name"
-      "\tcbexternal@run@tex"
-    }%
-  }%
-  \endgroup%
-}
+\ExplSyntaxOn
+\cs_new_protected:Npn \tcbexternal@corecompile
+  {
+    \group_begin:
+    \char_set_catcode_other:n { `\" }
+    \iow_term:e { ===~Compile~external~'\tcbexternal@job@name':~ }
+    \tcb@allocate@tcb@out
+    \iow_open:No \tcb@out { \tcbexternal@run@tex }
+    \iow_now:Ne \tcb@out
+      {
+        \token_to_str:N \gdef \token_to_str:N \TCBEXTERNALINPUT
+          { "\tcbexternal@job@source" } \iow_newline:
+        \token_to_str:N \gdef \token_to_str:N \TCBEXTERNALSAFETY
+          { \tcbexternal@safety } \iow_newline:
+        \token_to_str:N \gdef \token_to_str:N \TCBEXTERNALPREAMBLE
+          { \exp_not:o {\tcbexternal@preamble} }
+      }
+    \tl_if_empty:NF \tcbexternal@preclass
+      { \iow_now:No \tcb@out { \tcbexternal@preclass } }
+    \iow_now:No \tcb@out
+        { \token_to_str:N \input{"\jobname.tex"} }
+    \iow_close:N \tcb@out
+    \int_step_inline:nn { \tcbexternal@runs }
+      {
+        \sys_shell_now:e
+          {
+            \tcbexternal@compiler~
+            -shell-escape~
+            -halt-on-error~
+            -interaction=batchmode~
+            -jobname="\tcbexternal@job@name"~
+            "\tcbexternal@run@tex"
+          }
+      }
+    \group_end:
+  }
+
+\cs_generate_variant:Nn \iow_now:Nn { No }
+\ExplSyntaxOff
 
 \def\tcbexternal@compile#1{%
   \tcbiffileprocess{#1}%

--- a/tex/latex/tcolorbox/tcbexternal.code.tex
+++ b/tex/latex/tcolorbox/tcbexternal.code.tex
@@ -79,7 +79,7 @@
   \immediate\closeout\tcb@out%
   \foreach \n in {1,...,\tcbexternal@runs}
   {%
-    \ShellEscape{%
+    \UseName{sys_shell:now:e}{%
       \tcbexternal@compiler\space
       -shell-escape
       -halt-on-error

--- a/tex/latex/tcolorbox/tcbexternal.code.tex
+++ b/tex/latex/tcolorbox/tcbexternal.code.tex
@@ -65,8 +65,8 @@
     \char_set_catcode_other:n { `\" }
     \iow_term:e { ===~Compile~external~'\tcbexternal@job@name':~ }
     \tcb@allocate@tcb@out
-    \iow_open:Nn \tcb@out { \tcbexternal@run@tex }
-    \iow_now:Ne \tcb@out
+    \iow_open:Nn \g_tcb_out_iow { \tcbexternal@run@tex }
+    \iow_now:Ne \g_tcb_out_iow
       {
         \token_to_str:N \gdef \token_to_str:N \TCBEXTERNALINPUT
           { "\tcbexternal@job@source" } \iow_newline:
@@ -76,10 +76,10 @@
           { \exp_not:o {\tcbexternal@preamble} }
       }
     \tl_if_empty:NF \tcbexternal@preclass
-      { \iow_now:No \tcb@out { \tcbexternal@preclass } }
-    \iow_now:No \tcb@out
+      { \iow_now:No \g_tcb_out_iow { \tcbexternal@preclass } }
+    \iow_now:Ne \g_tcb_out_iow
         { \token_to_str:N \input {"\jobname.tex"} }
-    \iow_close:N \tcb@out
+    \iow_close:N \g_tcb_out_iow
     \int_step_inline:nn { \tcbexternal@runs }
       {
         \sys_shell_now:e
@@ -246,22 +246,22 @@
     \let\tcbexternal@out@end=\@empty%
   },
   minipage/.code={%
-    \appto\tcbexternal@out@begin{\immediate\write\tcb@out{\string\begin{minipage}{\the\dimexpr#1\relax}\string\ignorespaces\@percentchar}}%
-    \preto\tcbexternal@out@end{\immediate\write\tcb@out{\string\end{minipage}\@percentchar}}%
+    \appto\tcbexternal@out@begin{\tcb@iow@write{\string\begin{minipage}{\the\dimexpr#1\relax}\string\ignorespaces\@percentchar}}%
+    \preto\tcbexternal@out@end{\tcb@iow@write{\string\end{minipage}\@percentchar}}%
   },
   minipage/.default=\linewidth,
   %
   environment with percent/.is choice,
   environment with percent/true/.style={%
     /tcb/external/environment/.code={%
-      \appto\tcbexternal@out@begin{\immediate\write\tcb@out{\string\begin{##1}\@percentchar}}%
-      \preto\tcbexternal@out@end{\immediate\write\tcb@out{\string\end{##1}\@percentchar}}%
+      \appto\tcbexternal@out@begin{\tcb@iow@write{\string\begin{##1}\@percentchar}}%
+      \preto\tcbexternal@out@end{\tcb@iow@write{\string\end{##1}\@percentchar}}%
     }
   },
   environment with percent/false/.style={%
     /tcb/external/environment/.code={%
-      \appto\tcbexternal@out@begin{\immediate\write\tcb@out{\string\begin{##1}}}%
-      \preto\tcbexternal@out@end{\immediate\write\tcb@out{\string\end{##1}}}%
+      \appto\tcbexternal@out@begin{\tcb@iow@write{\string\begin{##1}}}%
+      \preto\tcbexternal@out@end{\tcb@iow@write{\string\end{##1}}}%
     }
   },
   environment with percent/.default=true,

--- a/tex/latex/tcolorbox/tcblistingscore.code.tex
+++ b/tex/latex/tcolorbox/tcblistingscore.code.tex
@@ -164,15 +164,27 @@
   \begin{tcolorbox}[capture=\tcb@listing@capture,savedelimiter=tcolorbox]\tcb@listing@process\end{tcolorbox}%
 }
 
-\long\def\tcb@run@system@command#1{%
-  \ifcase\pdf@shellescape\relax
-    \tcb@error{You must invoke LaTeX with the -shell-escape flag}{Pass the -shell-escape flag to LaTeX.}%
-  \or\or
-    \tcb@warning{System call with restricted shell escape may fail}%
-  \fi%
-  \ShellEscape{#1}%
-  \relax%
-}
+\ExplSyntaxOn
+\cs_new_protected:Npn \tcb@run@system@command #1
+  {
+    % Depending on the current shell escape status,
+    % \sys_if_shell:TF and \sys_if_shell_restricted:TF are both let to either
+    % \use_i:ii or \use_ii:ii, hence efficient enough.
+    \sys_if_shell:TF
+      {
+        \sys_if_shell_restricted:T
+          {
+            \tcb@warning{System~call~with~restricted~shell~escape~may~fail}
+          }
+      }
+      {
+        \tcb@error{You~must~invoke~LaTeX~with~the~-shell-escape~flag}
+          {Pass~the -shell-escape~flag~to~LaTeX.}
+      }
+    \sys_shell_now:e {#1}
+    \scan_stop: % necessary?
+  }
+\ExplSyntaxOff
 
 
 \tcbset{%

--- a/tex/latex/tcolorbox/tcblistingscore.code.tex
+++ b/tex/latex/tcolorbox/tcblistingscore.code.tex
@@ -169,7 +169,7 @@
   {
     % Depending on the current shell escape status,
     % \sys_if_shell:TF and \sys_if_shell_restricted:TF are both let to either
-    % \use_i:ii or \use_ii:ii, hence efficient enough.
+    % \use_i:nn or \use_ii:nn, hence efficient enough.
     \sys_if_shell:TF
       {
         \sys_if_shell_restricted:T

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -20,42 +20,43 @@
 \tcb@set@library@version{6.2.0pre2}
 
 \ExplSyntaxOn
-\str_new:N \l__tcb_proc_last_hash_str
-\str_new:N \l__tcb_proc_curr_hash_str
+\str_new:N \l__tcobox_proc_last_hash_str
+\str_new:N \l__tcobox_proc_curr_hash_str
 
-\cs_new_protected:Npn \__tcbproc_read_mdfive:nn #1#2
+\cs_new_protected:Npn \__tcobox_read_mdfive:nn #1#2
   {
-    \str_set:Ne \l__tcb_proc_last_hash_str { \file_mdfive_hash:n {#1} }
+    \str_set:Ne \l__tcobox_proc_last_hash_str { \file_mdfive_hash:n {#1} }
     \file_if_exist_input:nF {#2}
-      { \str_clear:N \l__tcb_proc_last_hash_str }
+      { \str_clear:N \l__tcobox_proc_last_hash_str }
   }
 
-\cs_new_protected:Npn \__tcbproc_write_mdfive:nn #1
+\cs_new_protected:Npn \__tcobox_write_mdfive:nn #1
   {
-    \iow_open:Nn \g__tcb_out_iow {#1}
-    \iow_now:Ne \g__tcb_out_iow
+    \iow_open:Nn \g__tcobox_out_iow {#1}
+    \iow_now:Ne \g__tcobox_out_iow
       {
+        % safe and worthy?
         \token_to_str:N \ExplSyntaxOn
-        \token_to_str:N \def \token_to_str:N \l__tcb_proc_last_hash_str
-          { \l__tcb_proc_curr_hash_str }
+        \token_to_str:N \def \token_to_str:N \l__tcobox_proc_last_hash_str
+          { \l__tcobox_proc_curr_hash_str }
         \token_to_str:N \ExplSyntaxOff
       }
-    \iow_close:N \g__tcb_out_iow
+    \iow_close:N \g__tcobox_out_iow
   }
 
-\cs_new_protected:Npn \__tcbif_process_on:nnnTF #1#2#3
+\cs_new_protected:Npn \__tcobox_if_process_on:nnnTF #1#2#3
   {
-    \__tcbproc_read_mdfive:nn {#1} {#2}
-    \str_if_eq:NNF \l__tcb_proc_last_hash_str \l__tcb_proc_curr_hash_str
-      { \__tcbproc_write_mdfive:nn{#2} }
+    \__tcobox_read_mdfive:nn {#1} {#2}
+    \str_if_eq:NNF \l__tcobox_proc_last_hash_str \l__tcobox_proc_curr_hash_str
+      { \__tcobox_write_mdfive:nn {#2} }
     \use_i:nn
   }
 
 % define it by \prg_new_protected_conditional:Npnn?
-\cs_new_protected:Npn \__tcbif_process_conditional:nnnTF #1#2#3
+\cs_new_protected:Npn \__tcobox_if_process_conditional:nnnTF #1#2#3
   {
-    \__tcbproc_read_mdfive:nn {#1} {#2}
-    \str_if_eq:NNTF \l__tcb_proc_last_hash_str \l__tcb_proc_curr_hash_str
+    \__tcobox_read_mdfive:nn {#1} {#2}
+    \str_if_eq:NNTF \l__tcobox_proc_last_hash_str \l__tcobox_proc_curr_hash_str
       {
         \file_if_exist:nTF {#3}
           {
@@ -66,28 +67,28 @@
           { \use_i:nn }
       }
       {
-        \__tcbproc_write_mdfive:nn {#2}
+        \__tcobox_write_mdfive:nn {#2}
         \use_i:nn
       }
   }
 
-\cs_new_protected:Npn \__tcbif_process_off:nnnTF #1#2#3
+\cs_new_protected:Npn \__tcobox_if_process_off:nnnTF #1#2#3
   {
-    \__tcbproc_read_mdfive:nn {#1} {#2}
-    \str_if_eq:NNF \l__tcb_proc_last_hash_str \l__tcb_proc_curr_hash_str
-      { \__tcbproc_write_mdfive:nn{#2} }
+    \__tcobox_read_mdfive:nn {#1} {#2}
+    \str_if_eq:NNF \l__tcobox_proc_last_hash_str \l__tcobox_proc_curr_hash_str
+      { \__tcobox_write_mdfive:nn {#2} }
     \use_ii:nn
   }
 
-\cs_new_protected:Npn \__tcbif_file_process:nnnnTF #1
+\cs_new_protected:Npn \__tcobox_if_file_process:nnnnTF #1
   {
     \int_case:nn {#1}
       {
-        {0} { \__tcbif_process_on:nnnTF }
-        {1} { \__tcbif_process_conditional:nnnTF }
-        {2} { \__tcbif_process_off:nnnTF }
+        {0} { \__tcobox_if_process_on:nnnTF }
+        {1} { \__tcobox_if_process_conditional:nnnTF }
+        {2} { \__tcobox_if_process_off:nnnTF }
       }
   }
-\cs_gset_eq:NN \tcbiffileprocess \__tcbif_file_process:nnnnTF
+\cs_gset_eq:NN \tcbiffileprocess \__tcobox_if_file_process:nnnnTF
 
 \ExplSyntaxOff

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -22,17 +22,18 @@
 \RequirePackage{pdftexcmds}
 \RequirePackage{shellesc}
 
-\ifdefined\pdf@filemdfivesum\else% XeLaTeX presumed ...
-  \def\pdf@filemdfivesum#1{\mdfivesum file {#1}}%
-\fi
 \ifdefined\pdf@filemoddate\else% very poor XeLaTeX bypassing
   \def\pdf@filemoddate#1{}%
 \fi
 
-\def\tcbproc@readmdfive#1#2{%
-  \edef\tcbprocmdfivesum{\pdf@filemdfivesum{#1}}%
-  \IfFileExists{#2}{\input{#2}}{\def\tcbproclastmdfivesum{}}%
-}
+\ExplSyntaxOn
+\cs_new_protected:Npn \tcbproc@readmdfive #1#2
+  {
+    \tl_set:Ne \tcbproclastmdfivesum { \file_mdfive_hash:n {#1} }
+    \file_if_exist_input:nF {#2}
+      { \tl_set_eq:NN \tcbproclastmdfivesum \c_empty_tl }
+  }
+\ExplSyntaxOff
 
 \def\tcbproc@writemdfive#1{%
   \tcb@allocate@tcb@out%

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -22,10 +22,6 @@
 \RequirePackage{pdftexcmds}
 \RequirePackage{shellesc}
 
-\ifdefined\pdf@filemoddate\else% very poor XeLaTeX bypassing
-  \def\pdf@filemoddate#1{}%
-\fi
-
 \ExplSyntaxOn
 \cs_new_protected:Npn \tcbproc@readmdfive #1#2
   {
@@ -48,21 +44,28 @@
   \expandafter\@firstoftwo%
 }
 
-\newrobustcmd{\iftcb@process@conditional}[3]{%
-  \tcbproc@readmdfive{#1}{#2}%
-  \ifdefstrequal{\tcbproclastmdfivesum}{\tcbprocmdfivesum}{%
-    \IfFileExists{#3}{%
-      \ifnum\pdf@strcmp{\pdf@filemoddate{#2}}{\pdf@filemoddate{#3}}>0\relax%
-        \expandafter\@firstoftwo%
-      \else%
-        \expandafter\@secondoftwo%
-      \fi%
-    }{\expandafter\@firstoftwo}%
-  }{%
-    \tcbproc@writemdfive{#2}%
-    \expandafter\@firstoftwo%
-  }%
-}
+\ExplSyntaxOn
+% TODO: define it by \prg_new_protected_conditional:Npnn.
+%       Then csname must contain ":".
+\cs_new_protected:Npn \iftcb@process@conditional #1#2#3
+  {
+    \tcbproc@readmdfive {#1} {#2}
+    \str_if_eq:ooTF { \tcbproclastmdfivesum } { \tcbprocmdfivesum }
+      {
+        \file_if_exist:nTF {#3}
+          {
+            \str_if_eq:eeTF { \file_timestamp:n {#2} }{ \file_timestamp:n {#3} }
+              { \use_ii:ii }
+              { \use_i:ii }
+          }
+          { \use_i:nn }
+      }
+      {
+        \tcbproc@writemdfive{#2}
+        \use_i:nn
+      }
+  }
+\ExplSyntaxOff
 
 \newrobustcmd{\iftcb@process@off}[3]{%
   \tcbproc@readmdfive{#1}{#2}%

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -31,18 +31,18 @@
   }
 
 \cs_new_protected:Npn \__tcbproc_write_mdfive:nn #1
-{
-  \tcb@allocate@tcb@out
-  \iow_open:Nn \tcb@out {#1}
-  \iow_now:Ne \tcb@out
-    {
-      \token_to_str:N \ExplSyntaxOn
-      \token_to_str:N \def \token_to_str:N \l__tcb_proc_last_hash_str
-        { \l__tcb_proc_curr_hash_str }
-      \token_to_str:N \ExplSyntaxOff
-    }
-  \iow_close:N \tcb@out
-}
+  {
+    \tcb@allocate@tcb@out
+    \iow_open:Nn \g_tcb_out_iow {#1}
+    \iow_now:Ne \g_tcb_out_iow
+      {
+        \token_to_str:N \ExplSyntaxOn
+        \token_to_str:N \def \token_to_str:N \l__tcb_proc_last_hash_str
+          { \l__tcb_proc_curr_hash_str }
+        \token_to_str:N \ExplSyntaxOff
+      }
+    \iow_close:N \g_tcb_out_iow
+  }
 
 \cs_new_protected:Npn \__tcbif_process_on:nnnTF #1#2#3
   {

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -19,9 +19,6 @@
 %%
 \tcb@set@library@version{6.2.0pre2}
 
-\RequirePackage{pdftexcmds}
-\RequirePackage{shellesc}
-
 \ExplSyntaxOn
 \cs_new_protected:Npn \tcbproc@readmdfive #1#2
   {

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -20,34 +20,40 @@
 \tcb@set@library@version{6.2.0pre2}
 
 \ExplSyntaxOn
+
 \cs_new_protected:Npn \tcbproc@readmdfive #1#2
   {
     \tl_set:Ne \tcbproclastmdfivesum { \file_mdfive_hash:n {#1} }
     \file_if_exist_input:nF {#2}
       { \tl_set_eq:NN \tcbproclastmdfivesum \c_empty_tl }
   }
-\ExplSyntaxOff
 
-\def\tcbproc@writemdfive#1{%
-  \tcb@allocate@tcb@out%
-  \immediate\openout\tcb@out=#1%
-  \immediate\write\tcb@out{\string\def\string\tcbproclastmdfivesum{\tcbprocmdfivesum}\@percentchar}%
-  \immediate\closeout\tcb@out%
+\cs_new_protected:Npn \tcbproc@writemdfive #1
+{
+  \tcb@allocate@tcb@out
+  \iow_open:Nn \tcb@out {#1}
+  \iow_now:Ne \tcb@out
+    {
+      \token_to_str:N \def \token_to_str:N \tcbproclastmdfivesum
+        { \tcbprocmdfivesum } \c_percent_str
+    }
+  \iow_close:N \tcb@out
 }
 
-\newrobustcmd{\iftcb@process@on}[3]{%
-  \tcbproc@readmdfive{#1}{#2}%
-  \ifdefstrequal{\tcbproclastmdfivesum}{\tcbprocmdfivesum}{}{\tcbproc@writemdfive{#2}}%
-  \expandafter\@firstoftwo%
-}
+\cs_new_protected:Npn \iftcb@process@on #1#2#3
+  {
+    \tcbproc@readmdfive {#1} {#2}
+    \str_if_eq:NNF \tcbproclastmdfivesum \tcbprocmdfivesum
+      { \tcbproc@writemdfive{#2} }
+    \use_i:ii
+  }
 
-\ExplSyntaxOn
 % TODO: define it by \prg_new_protected_conditional:Npnn.
 %       Then csname must contain ":".
 \cs_new_protected:Npn \iftcb@process@conditional #1#2#3
   {
     \tcbproc@readmdfive {#1} {#2}
-    \str_if_eq:ooTF { \tcbproclastmdfivesum } { \tcbprocmdfivesum }
+    \str_if_eq:NNTF \tcbproclastmdfivesum \tcbprocmdfivesum
       {
         \file_if_exist:nTF {#3}
           {
@@ -58,24 +64,27 @@
           { \use_i:nn }
       }
       {
-        \tcbproc@writemdfive{#2}
+        \tcbproc@writemdfive {#2}
         \use_i:nn
       }
   }
+
+\cs_new_protected:Npn \iftcb@process@off #1#2#3
+  {
+    \tcbproc@readmdfive {#1} {#2}
+    \str_if_eq:NNF \tcbproclastmdfivesum \tcbprocmdfivesum
+      { \tcbproc@writemdfive{#2} }
+    \use_ii:nn
+  }
+
+\cs_new_protected:Npn \tcbiffileprocess #1
+  {
+    \int_case:nn {#1}
+      {
+        {0} { \iftcb@process@on }
+        {1} { \iftcb@process@conditional }
+        {2} { \iftcb@process@off }
+      }
+  }
+
 \ExplSyntaxOff
-
-\newrobustcmd{\iftcb@process@off}[3]{%
-  \tcbproc@readmdfive{#1}{#2}%
-  \ifdefstrequal{\tcbproclastmdfivesum}{\tcbprocmdfivesum}{}{\tcbproc@writemdfive{#2}}%
-  \expandafter\@secondoftwo%
-}%
-
-\newrobustcmd{\tcbiffileprocess}[1]{%
-  \ifcase\numexpr#1\relax%
-    \expandafter\iftcb@process@on%
-  \or%
-    \expandafter\iftcb@process@conditional%
-  \else%
-    \expandafter\iftcb@process@off%
-  \fi%
-}

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -21,39 +21,40 @@
 
 \ExplSyntaxOn
 
-\cs_new_protected:Npn \tcbproc@readmdfive #1#2
+\cs_new_protected:Npn \__tcbproc_read_mdfive:nn #1#2
   {
-    \tl_set:Ne \tcbproclastmdfivesum { \file_mdfive_hash:n {#1} }
+    \str_set:Ne \l__tcb_proc_last_hash_str { \file_mdfive_hash:n {#1} }
     \file_if_exist_input:nF {#2}
-      { \tl_set_eq:NN \tcbproclastmdfivesum \c_empty_tl }
+      { \str_clear:N \l__tcb_proc_last_hash_str }
   }
 
-\cs_new_protected:Npn \tcbproc@writemdfive #1
+\cs_new_protected:Npn \__tcbproc_write_mdfive:nn #1
 {
   \tcb@allocate@tcb@out
   \iow_open:Nn \tcb@out {#1}
   \iow_now:Ne \tcb@out
     {
-      \token_to_str:N \def \token_to_str:N \tcbproclastmdfivesum
-        { \tcbprocmdfivesum } \c_percent_str
+      \token_to_str:N \ExplSyntaxOn
+      \token_to_str:N \def \token_to_str:N \l__tcb_proc_last_hash_str
+        { \l__tcb_proc_curr_hash_str }
+      \token_to_str:N \ExplSyntaxOff
     }
   \iow_close:N \tcb@out
 }
 
-\cs_new_protected:Npn \iftcb@process@on #1#2#3
+\cs_new_protected:Npn \__tcbif_process_on:nnnTF #1#2#3
   {
-    \tcbproc@readmdfive {#1} {#2}
-    \str_if_eq:NNF \tcbproclastmdfivesum \tcbprocmdfivesum
-      { \tcbproc@writemdfive{#2} }
+    \__tcbproc_read_mdfive:nn {#1} {#2}
+    \str_if_eq:NNF \l__tcb_proc_last_hash_str \l__tcb_proc_curr_hash_str
+      { \__tcbproc_write_mdfive:nn{#2} }
     \use_i:ii
   }
 
-% TODO: define it by \prg_new_protected_conditional:Npnn.
-%       Then csname must contain ":".
-\cs_new_protected:Npn \iftcb@process@conditional #1#2#3
+% define it by \prg_new_protected_conditional:Npnn?
+\cs_new_protected:Npn \__tcbif_process_conditional:nnnTF #1#2#3
   {
-    \tcbproc@readmdfive {#1} {#2}
-    \str_if_eq:NNTF \tcbproclastmdfivesum \tcbprocmdfivesum
+    \__tcbproc_read_mdfive:nn {#1} {#2}
+    \str_if_eq:NNTF \l__tcb_proc_last_hash_str \l__tcb_proc_curr_hash_str
       {
         \file_if_exist:nTF {#3}
           {
@@ -64,27 +65,28 @@
           { \use_i:nn }
       }
       {
-        \tcbproc@writemdfive {#2}
+        \__tcbproc_write_mdfive:nn {#2}
         \use_i:nn
       }
   }
 
-\cs_new_protected:Npn \iftcb@process@off #1#2#3
+\cs_new_protected:Npn \__tcbif_process_off:nnnTF #1#2#3
   {
-    \tcbproc@readmdfive {#1} {#2}
-    \str_if_eq:NNF \tcbproclastmdfivesum \tcbprocmdfivesum
-      { \tcbproc@writemdfive{#2} }
+    \__tcbproc_read_mdfive:nn {#1} {#2}
+    \str_if_eq:NNF \l__tcb_proc_last_hash_str \l__tcb_proc_curr_hash_str
+      { \__tcbproc_write_mdfive:nn{#2} }
     \use_ii:nn
   }
 
-\cs_new_protected:Npn \tcbiffileprocess #1
+\cs_new_protected:Npn \__tcbif_file_process:nnnnTF #1
   {
     \int_case:nn {#1}
       {
-        {0} { \iftcb@process@on }
-        {1} { \iftcb@process@conditional }
-        {2} { \iftcb@process@off }
+        {0} { \__tcbif_process_on:nnnTF }
+        {1} { \__tcbif_process_conditional:nnnTF }
+        {2} { \__tcbif_process_off:nnnTF }
       }
   }
+\cs_gset_eq:NN \__tcbif_file_process:nnnTF \tcbiffileprocess
 
 \ExplSyntaxOff

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -32,16 +32,15 @@
 
 \cs_new_protected:Npn \__tcbproc_write_mdfive:nn #1
   {
-    \tcb@allocate@tcb@out
-    \iow_open:Nn \g_tcb_out_iow {#1}
-    \iow_now:Ne \g_tcb_out_iow
+    \iow_open:Nn \g__tcb_out_iow {#1}
+    \iow_now:Ne \g__tcb_out_iow
       {
         \token_to_str:N \ExplSyntaxOn
         \token_to_str:N \def \token_to_str:N \l__tcb_proc_last_hash_str
           { \l__tcb_proc_curr_hash_str }
         \token_to_str:N \ExplSyntaxOff
       }
-    \iow_close:N \g_tcb_out_iow
+    \iow_close:N \g__tcb_out_iow
   }
 
 \cs_new_protected:Npn \__tcbif_process_on:nnnTF #1#2#3

--- a/tex/latex/tcolorbox/tcbprocessing.code.tex
+++ b/tex/latex/tcolorbox/tcbprocessing.code.tex
@@ -20,6 +20,8 @@
 \tcb@set@library@version{6.2.0pre2}
 
 \ExplSyntaxOn
+\str_new:N \l__tcb_proc_last_hash_str
+\str_new:N \l__tcb_proc_curr_hash_str
 
 \cs_new_protected:Npn \__tcbproc_read_mdfive:nn #1#2
   {
@@ -47,7 +49,7 @@
     \__tcbproc_read_mdfive:nn {#1} {#2}
     \str_if_eq:NNF \l__tcb_proc_last_hash_str \l__tcb_proc_curr_hash_str
       { \__tcbproc_write_mdfive:nn{#2} }
-    \use_i:ii
+    \use_i:nn
   }
 
 % define it by \prg_new_protected_conditional:Npnn?
@@ -59,8 +61,8 @@
         \file_if_exist:nTF {#3}
           {
             \str_if_eq:eeTF { \file_timestamp:n {#2} }{ \file_timestamp:n {#3} }
-              { \use_ii:ii }
-              { \use_i:ii }
+              { \use_ii:nn }
+              { \use_i:nn }
           }
           { \use_i:nn }
       }
@@ -87,6 +89,6 @@
         {2} { \__tcbif_process_off:nnnTF }
       }
   }
-\cs_gset_eq:NN \__tcbif_file_process:nnnTF \tcbiffileprocess
+\cs_gset_eq:NN \tcbiffileprocess \__tcbif_file_process:nnnnTF
 
 \ExplSyntaxOff

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2688,36 +2688,42 @@
 
 % recording
 
-\def\tcb@allocate@tcb@record@out{%
-  \newwrite\tcb@record@out%
-  \xdef\tcb@allocate@tcb@record@out{}%
-}
+\ExplSyntaxOn
+\iow_new:N \g__tcb_record_iow
 
+\cs_new_protected:Npn \__tcb_record:n #1
+  { \iow_now:Ne \g__tcb_record_iow {#1} }
 
-\def\tcb@null#1{}
-\newcommand{\tcb@record}[1]{\immediate\write\tcb@record@out{#1}}
+\NewDocumentCommand \tcbstartrecording { O{\jobname.records} }
+  {
+    \cs_set_eq:NN \tcbrecord \__tcb_record:n
+    % or str?
+    \tl_set:Ne \l__tcb_record_file_tl {#1}
+    \iow_open:Nn \g__tcb_record_iow {\l__tcb_record_file_tl}
+  }
 
-\newcommand{\tcbstartrecording}[1][\jobname.records]{%
-  \let\tcbrecord\tcb@record%
-  \edef\tcb@record@file{#1}%
-  \tcb@allocate@tcb@record@out%
-  \immediate\openout\tcb@record@out\tcb@record@file%
-}
+\NewDocumentCommand \tcbstoprecording { }
+  {
+    \iow_close:N \g__tcb_record_iow
+    \cs_set_eq:NN \tcbrecord \use_none:n
+  }
 
-\newcommand{\tcbstoprecording}{%
-  \immediate\closeout\tcb@record@out%
-  \let\tcbrecord\tcb@null%
-}
-
-\tcbset{%
+\tcbset{
   record/.style={phantom={\tcbrecord{#1}}},
-  no recording/.code={\let\tcbrecord\tcb@null},
-  no recording
+  no~recording/.code={ \cs_set_eq:NN \tcbrecord \use_none:n },
+  no~recording
 }
 
-\newcommand{\tcbinputrecords}[1][\tcb@record@file]{%
-  \IfFileExists{#1}{\input{#1}}{\tcb@error{record file `#1' not found}{The record file `#1' was not found}}%
-}
+\NewDocumentCommand \tcbinputrecords { O{\l__tcb_record_file_tl} }
+  {
+    \file_if_exist_input:nF {#1}
+      {
+        \tcb@error{record~file~`#1'~not~found}
+          {The~record~file~`#1'~was~not~found}
+      }
+  }
+
+\ExplSyntaxOff
 
 \tcb@new@skin{standard}{frame engine=standard,interior titled engine=standard,
   interior engine=standard,segmentation engine=standard,title engine=standard,

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2568,15 +2568,22 @@
 
 % verbatim output as in 'verbatim'
 
+% Once a stream is declared by \iow_new:N, it can never be used by \openout
+% (error "! Bad number (16)." will be thrown).
+% This is because expl3 uses a pool of streams thus an iow stream is
+% initialized to \c_term_iow (16), and only allocated to a non-terminal
+% stream number when it's opened by \iow_open:Nn.
 \ExplSyntaxOn
 \cs_new_protected:Npn \tcb@allocate@tcb@out
   {
-    % TODO: more latex3-nic name is \g_tcb_out_iow
-    % FIXME: why \iow_new:N caused "! Bad number (16)" error?
-    \newwrite \tcb@out
-    % FIXME: must be global? before \xdef\xxx{} was used
+    \iow_new:N \g_tcb_out_iow
     \cs_gset_eq:NN \tcb@allocate@tcb@out \prg_do_nothing:
   }
+
+% wrappers to be used in non-expl3 context
+\cs_new_protected:Npn \tcb@iow@open  { \iow_open:Nn \g_tcb_out_iow }
+\cs_new_protected:Npn \tcb@iow@write { \iow_now:Ne  \g_tcb_out_iow }
+\cs_new_protected:Npn \tcb@iow@close { \iow_close:N \g_tcb_out_iow }
 \ExplSyntaxOff
 
 \let\tcb@verbatim@begin@hook\@empty
@@ -2588,19 +2595,18 @@
   \@bsphack
   \tcb@set@verbatim@finish%
   \tcb@allocate@tcb@out%
-  \immediate\openout\tcb@out #1
+  \tcb@iow@open{#1}%
   \tcb@verbatim@begin@hook%
   \let\do\@makeother\dospecials
   \tcb@verbatim@change@percent\catcode`\^^M\active \catcode`\^^I=12
   \def\verbatim@processline{%
-    \immediate\write\tcb@out
-      {\the\verbatim@line}}%
+    \tcb@iow@write{\the\verbatim@line}}%
   \verbatim@start}%'
 
 
 \def\endtcbverbatimwrite{%
   \tcb@verbatim@end@hook%
-  \immediate\closeout\tcb@out
+  \tcb@iow@close
   \@esphack%
 }
 

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2568,10 +2568,14 @@
 
 % verbatim output as in 'verbatim'
 
-\def\tcb@allocate@tcb@out{%
-  \newwrite\tcb@out%
-  \xdef\tcb@allocate@tcb@out{}%
-}
+\ExplSyntaxOn
+\cs_new_protected:Npn \tcb@allocate@tcb@out
+  {
+    % more latex3-nic name is \g_tcb_out_iow
+    \iow_new:N \tcb@out
+    \cs_gclear:N \tcb@allocate@tcb@out
+  }
+\ExplSyntaxOff
 
 \let\tcb@verbatim@begin@hook\@empty
 \let\tcb@verbatim@end@hook\@empty

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2568,22 +2568,20 @@
 
 % verbatim output as in 'verbatim'
 
-% Once a stream is declared by \iow_new:N, it can never be used by \openout
-% (error "! Bad number (16)." will be thrown).
+\ExplSyntaxOn
+% A stream declared by \iow_new:N is not ready to be used by \openout.
+% If used error "! Bad number (16)." will thrown.
 % This is because expl3 uses a pool of streams thus an iow stream is
 % initialized to \c_term_iow (16), and only allocated to a non-terminal
 % stream number when it's opened by \iow_open:Nn.
-\ExplSyntaxOn
-\cs_new_protected:Npn \tcb@allocate@tcb@out
-  {
-    \iow_new:N \g_tcb_out_iow
-    \cs_gset_eq:NN \tcb@allocate@tcb@out \prg_do_nothing:
-  }
+% The benefit is, we can create \g__tcb_out_iow and \g__tcb_record_iow
+% globally, with no fear of allocated multiple times.
+\iow_new:N \g__tcb_out_iow
 
 % wrappers to be used in non-expl3 context
-\cs_new_protected:Npn \tcb@iow@open  { \iow_open:Nn \g_tcb_out_iow }
-\cs_new_protected:Npn \tcb@iow@write { \iow_now:Ne  \g_tcb_out_iow }
-\cs_new_protected:Npn \tcb@iow@close { \iow_close:N \g_tcb_out_iow }
+\cs_new_protected:Npn \tcb@iow@open  { \iow_open:Nn \g__tcb_out_iow }
+\cs_new_protected:Npn \tcb@iow@write { \iow_now:Ne  \g__tcb_out_iow }
+\cs_new_protected:Npn \tcb@iow@close { \iow_close:N \g__tcb_out_iow }
 \ExplSyntaxOff
 
 \let\tcb@verbatim@begin@hook\@empty
@@ -2594,7 +2592,6 @@
 \def\tcbverbatimwrite#1{%
   \@bsphack
   \tcb@set@verbatim@finish%
-  \tcb@allocate@tcb@out%
   \tcb@iow@open{#1}%
   \tcb@verbatim@begin@hook%
   \let\do\@makeother\dospecials

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2574,14 +2574,14 @@
 % This is because expl3 uses a pool of streams thus an iow stream is
 % initialized to \c_term_iow (16), and only allocated to a non-terminal
 % stream number when it's opened by \iow_open:Nn.
-% The benefit is, we can create \g__tcb_out_iow and \g__tcb_record_iow
+% The benefit is, we can create \g__tcobox_out_iow and \g__tcobox_record_iow
 % globally, with no fear of allocated multiple times.
-\iow_new:N \g__tcb_out_iow
+\iow_new:N \g__tcobox_out_iow
 
 % wrappers to be used in non-expl3 context
-\cs_new_protected:Npn \tcb@iow@open  { \iow_open:Nn \g__tcb_out_iow }
-\cs_new_protected:Npn \tcb@iow@write { \iow_now:Ne  \g__tcb_out_iow }
-\cs_new_protected:Npn \tcb@iow@close { \iow_close:N \g__tcb_out_iow }
+\cs_new_protected:Npn \tcb@iow@open  { \iow_open:Nn \g__tcobox_out_iow }
+\cs_new_protected:Npn \tcb@iow@write { \iow_now:Ne  \g__tcobox_out_iow }
+\cs_new_protected:Npn \tcb@iow@close { \iow_close:N \g__tcobox_out_iow }
 \ExplSyntaxOff
 
 \let\tcb@verbatim@begin@hook\@empty
@@ -2689,22 +2689,22 @@
 % recording
 
 \ExplSyntaxOn
-\iow_new:N \g__tcb_record_iow
+\iow_new:N \g__tcobox_record_iow
 
-\cs_new_protected:Npn \__tcb_record:n #1
-  { \iow_now:Ne \g__tcb_record_iow {#1} }
+\cs_new_protected:Npn \__tcobox_record:n #1
+  { \iow_now:Ne \g__tcobox_record_iow {#1} }
 
 \NewDocumentCommand \tcbstartrecording { O{\jobname.records} }
   {
-    \cs_set_eq:NN \tcbrecord \__tcb_record:n
+    \cs_set_eq:NN \tcbrecord \__tcobox_record:n
     % or str?
-    \tl_set:Ne \l__tcb_record_file_tl {#1}
-    \iow_open:Nn \g__tcb_record_iow {\l__tcb_record_file_tl}
+    \tl_set:Ne \l__tcobox_record_file_tl {#1}
+    \iow_open:Nn \g__tcobox_record_iow {\l__tcobox_record_file_tl}
   }
 
 \NewDocumentCommand \tcbstoprecording { }
   {
-    \iow_close:N \g__tcb_record_iow
+    \iow_close:N \g__tcobox_record_iow
     \cs_set_eq:NN \tcbrecord \use_none:n
   }
 
@@ -2714,7 +2714,7 @@
   no~recording
 }
 
-\NewDocumentCommand \tcbinputrecords { O{\l__tcb_record_file_tl} }
+\NewDocumentCommand \tcbinputrecords { O{\l__tcobox_record_file_tl} }
   {
     \file_if_exist_input:nF {#1}
       {

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2571,9 +2571,11 @@
 \ExplSyntaxOn
 \cs_new_protected:Npn \tcb@allocate@tcb@out
   {
-    % more latex3-nic name is \g_tcb_out_iow
-    \iow_new:N \tcb@out
-    \cs_gclear:N \tcb@allocate@tcb@out
+    % TODO: more latex3-nic name is \g_tcb_out_iow
+    % FIXME: why \iow_new:N caused "! Bad number (16)" error?
+    \newwrite \tcb@out
+    % FIXME: must be global? before \xdef\xxx{} was used
+    \cs_gset_eq:NN \tcb@allocate@tcb@out \prg_do_nothing:
   }
 \ExplSyntaxOff
 


### PR DESCRIPTION
(Just for the record, so the commits are kept even after I delete the head branch.)

Starting with findings that `\pdf@filemoddate` is poorly by-passed in xelatex[^1], I found the `pdftexcmds` macros can all be replaced with expl3 functions. In this way, not only xelatex but also (u)ptex engines are supported.
https://github.com/muzimuzhi/tcolorbox/blob/18aecbbacc61445c178c3e9a35cadc588b3665bf/tex/latex/tcolorbox/tcbprocessing.code.tex#L28-L30

The process of rewriting relevant sets of macros in expl3 then resulted in the current change size, which has far beyond my initial idea.

What's changed
- `pro@cessing` lib (`tcbproccessing.code.tex`): `pdftexcmds` and `shellesc` packages are dropped
  - `\pdf@shellescape` replaced by `\sys_if_shell:TF` and `\sys_if_shell_restricted:TF`
  - `\pdf@filemdfivesum` replaced by `\file_mdfive_hash:n`
  - `\pdf@filemoddate` replaced by `\file_timestamp:n`
  - `\pdf@strcmp` replaced by `\str_if_eq:eeTF`
  - `\ShellEscape` replaced by `\sys_shell_now:e`
- `pro@cessing` lib: totally rewritten in expl3 code
- `external` lib: `\tcbexternal@corecompile` rewritten in expl3 code
- main package: two output streams `\tcb@out` and `\tcb@record@out` rewritten in expl3 code
  The new expl3-based output streams will only occupy number of simultaneous output streams when opened.
- main package: recording macros rewritten in expl3 code

What's checked
- Running `arara tcolorbox` on https://github.com/muzimuzhi/tcolorbox/commit/18aecbbacc61445c178c3e9a35cadc588b3665bf (6.2.0pre2) and ff51855592b3c099e73e8fd242de8cf39d5d0bbe produces (visually) identical PDFs, in the sense of `diff-pdf` tool (which uses cario and poppler).
  `diff-pdf -s -m --output-diff=diff.pdf tcolorbox-drop-pdftexcmds.pdf tcolorbox-6.2.0pre2.pdf`

Todo
- [ ] adapte docs, e.g., `/tcb/external/compiler`
- [ ] define `tcbprocessing.code.tex` macros by `\prg_new_conditional:Npnn` or `\prg_new_protected_conditional:Npnn`
- [x] change to module name `tcobox`
- [ ] Check naming style

[^1]: xetex adds `\filemoddate` in texlive 2019, see https://tug.org/texlive/doc/texlive-en/texlive-en.html#x1-880009.1.16.